### PR TITLE
RT-25: Password change endpoint

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,10 +2,9 @@ use argon2::password_hash::{Error, SaltString};
 use argon2::{PasswordHash, PasswordHasher, PasswordVerifier};
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 
-use crate::{
-    errors::AuthError,
-    models::{NewUser, User},
-};
+use crate::dto::CredentialsDto;
+use crate::models::NewUser;
+use crate::{errors::AuthError, models::User};
 
 pub const SESSION_LIFE_TIME: usize = 60 * 60 * 24;
 pub const SESSION_ID_LENGTH: usize = 128;
@@ -16,12 +15,6 @@ pub const RESET_PASSWORD_PATH: &str = "reset_password";
 const MIN_PASSWORD_LENGTH: usize = 6;
 const MIN_USERNAME_LENGTH: usize = 3;
 
-#[derive(serde::Deserialize)]
-pub struct Credentials {
-    pub email: String,
-    pub password: String,
-}
-
 pub fn hash_password(password: String) -> Result<String, Error> {
     let salt = SaltString::generate(OsRng);
     let argon = argon2::Argon2::default();
@@ -29,7 +22,7 @@ pub fn hash_password(password: String) -> Result<String, Error> {
     Ok(password_hash.to_string())
 }
 
-pub fn authorize_user(user: &User, credentials: &Credentials) -> Result<String, Error> {
+pub fn authorize_user(user: &User, credentials: &CredentialsDto) -> Result<String, Error> {
     let db_hash = PasswordHash::new(&user.password)?;
     let argon = argon2::Argon2::default();
     argon.verify_password(credentials.password.as_bytes(), &db_hash)?;

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -9,9 +9,11 @@ async fn main() {
             "/",
             rocket::routes![
                 rust_template::rocket_routes::authorization::login,
-                rust_template::rocket_routes::authorization::me,
                 rust_template::rocket_routes::authorization::signup,
                 rust_template::rocket_routes::authorization::reset_password,
+                rust_template::rocket_routes::authorization::change_password,
+                rust_template::rocket_routes::profile::me,
+                rust_template::rocket_routes::profile::update_password,
             ],
         )
         .attach(rust_template::rocket_routes::DbConnection::fairing())

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -1,0 +1,22 @@
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+pub struct NewUserDto {
+    pub username: String,
+    pub email: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct CredentialsDto {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct ResetPasswordEmailDto {
+    pub email: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct NewPasswordDto {
+    pub password: String,
+    pub confirmation: String,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,3 @@
-#[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
-pub struct NewUserDto {
-    pub username: String,
-    pub email: String,
-}
-
 #[derive(serde::Serialize, Debug, serde::Deserialize, PartialEq)]
 pub struct ApiError {
     pub error_type: String,
@@ -17,6 +11,7 @@ pub enum AuthError {
     InvalidUsername,
     InvalidEmail,
     InvalidPassword,
+    InvalidToken,
     UnavailableUsername,
     EmailInUse,
     EmailNotExist,
@@ -45,6 +40,11 @@ impl AuthError {
                 error_type: ERROR_TYPE.to_string(),
                 code: "invalid_password".to_string(),
                 message: "Invalid password".to_string(),
+            },
+            AuthError::InvalidToken => ApiError {
+                error_type: ERROR_TYPE.to_string(),
+                code: "invalid_token".to_string(),
+                message: "Invalid token".to_string(),
             },
             AuthError::UnavailableUsername => ApiError {
                 error_type: ERROR_TYPE.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ mod repositories;
 mod schema;
 
 pub mod commands;
+pub mod dto;
 pub mod errors;
 pub mod rocket_routes;

--- a/src/models.rs
+++ b/src/models.rs
@@ -35,17 +35,6 @@ pub struct NewUser {
     pub password: String,
 }
 
-#[derive(serde::Serialize)]
-pub struct NewUserDto {
-    pub username: String,
-    pub email: String,
-}
-
-#[derive(serde::Deserialize)]
-pub struct ResetPasswordEmailDto {
-    pub email: String,
-}
-
 #[derive(Queryable, Debug)]
 pub struct Role {
     pub id: i32,

--- a/src/rocket_routes/mod.rs
+++ b/src/rocket_routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod authorization;
+pub mod profile;
 
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;

--- a/src/rocket_routes/profile.rs
+++ b/src/rocket_routes/profile.rs
@@ -1,0 +1,40 @@
+use rocket::serde::json::{serde_json::json, Json, Value};
+use rocket::{futures::TryFutureExt, http::Status, response::status::Custom};
+
+use crate::{
+    auth::{self, is_password_valid},
+    dto::NewPasswordDto,
+    errors::AuthError,
+    models::User,
+    repositories::UserRepository,
+    rocket_routes::DbConnection,
+};
+
+use super::server_error;
+
+#[rocket::get("/profile/me")]
+pub fn me(user: User) -> Value {
+    json!(user)
+}
+
+#[rocket::put("/profile/password", format = "json", data = "<password_dto>")]
+pub async fn update_password(
+    password_dto: Json<NewPasswordDto>,
+    db: DbConnection,
+    user: User,
+) -> Result<Status, Custom<Value>> {
+    let is_confirmation_equal = password_dto.password == password_dto.confirmation;
+    if !is_confirmation_equal || !is_password_valid(&password_dto.password) {
+        return Err(Custom(
+            Status::BadRequest,
+            json!(AuthError::InvalidPassword.value()),
+        ));
+    }
+
+    let password_hash = auth::hash_password(password_dto.password.clone()).unwrap();
+
+    db.run(move |connection| UserRepository::update_password(connection, user.id, &password_hash))
+        .map_err(|e| server_error(e.into()))
+        .map_ok(|_f| Status::Ok)
+        .await
+}

--- a/tests/authorization.rs
+++ b/tests/authorization.rs
@@ -1,95 +1,25 @@
 use reqwest::{blocking::Client, StatusCode};
 use rocket::form::validate::Len;
-use rust_template::errors::{ApiError, AuthError, NewUserDto};
+use rust_template::{
+    dto::NewUserDto,
+    errors::{ApiError, AuthError},
+};
 use serde_json::{from_value, json, Value};
 
-use crate::common::{
-    create_test_user, delete_test_user, get_client_with_logged_in_editor,
-    get_client_with_logged_in_viewer,
-};
+use crate::common::{create_test_user, delete_test_user, generate_test_token};
 
 pub mod common;
 
-#[test]
-fn when_session_is_active_and_role_viewer_then_me_success() {
-    let client = get_client_with_logged_in_viewer();
-
-    let response = client
-        .get(format!("{}/me", common::APP_HOST))
-        .send()
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-}
-
-#[test]
-fn when_session_is_active_and_role_editor_then_me_success() {
-    let client = get_client_with_logged_in_editor();
-
-    let response = client
-        .get(format!("{}/me", common::APP_HOST))
-        .send()
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-}
-
-#[test]
-fn when_session_is_active_and_role_viewer_then_me_returns_username_and_email() {
-    let client = get_client_with_logged_in_viewer();
-
-    let response = client
-        .get(format!("{}/me", common::APP_HOST))
-        .send()
-        .unwrap();
-
-    let json: Value = response.json().unwrap();
-    assert_eq!(
-        {
-            json.get("username").unwrap();
-            json.get("email").unwrap();
-        },
-        {
-            "test_viewer";
-            "test_viewer@gmail.com";
-        },
-    );
-}
-
-#[test]
-fn when_session_is_active_and_me_success_then_password_is_none() {
-    let client = get_client_with_logged_in_viewer();
-
-    let response = client
-        .get(format!("{}/me", common::APP_HOST))
-        .send()
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let json: Value = response.json().unwrap();
-    assert!(json.get("password").is_none());
-}
-
-#[test]
-fn when_session_is_not_active_me_failed() {
-    let client = Client::new();
-
-    let response = client
-        .get(format!("{}/me", common::APP_HOST))
-        .send()
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-}
+const SESSION_ID_LENGTH: usize = 128;
 
 #[test]
 fn when_credentials_correct_then_login_success() {
-    let username = "test_viewer";
+    let username = format!("testViewer{}", rand::random::<u32>());
     let email = format!("{}@gmail.com", username);
     let password = "1234";
     let output = create_test_user(&username, &email, &password, "viewer");
 
-    println!("{:?}", output);
+    println!("1{:?}", output);
 
     let client = Client::new();
 
@@ -101,18 +31,21 @@ fn when_credentials_correct_then_login_success() {
         }))
         .send()
         .unwrap();
+
+    // Cleanup
+    delete_test_user(output);
 
     assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[test]
 fn when_credentials_correct_then_login_returns_token() {
-    let username = "test_viewer";
+    let username = format!("testViewer{}", rand::random::<u32>());
     let email = format!("{}@gmail.com", username);
     let password = "1234";
     let output = create_test_user(&username, &email, &password, "viewer");
 
-    println!("{:?}", output);
+    println!("2{:?}", output);
 
     let client = Client::new();
 
@@ -124,6 +57,9 @@ fn when_credentials_correct_then_login_returns_token() {
         }))
         .send()
         .unwrap();
+
+    // Cleanup
+    delete_test_user(output);
 
     let json: Value = response.json().unwrap();
     assert_eq!(json["token"].as_str().len(), 128);
@@ -131,11 +67,11 @@ fn when_credentials_correct_then_login_returns_token() {
 
 #[test]
 fn when_password_is_wrong_then_login_failed() {
-    let username = "test_viewer";
+    let username = format!("testViewer{}", rand::random::<u32>());
     let email = format!("{}@gmail.com", username);
     let output = create_test_user(&username, &email, "1234", "viewer");
 
-    println!("{:?}", output);
+    println!("3{:?}", output);
 
     let client = Client::new();
 
@@ -148,17 +84,20 @@ fn when_password_is_wrong_then_login_failed() {
         .send()
         .unwrap();
 
+    // Cleanup
+    delete_test_user(output);
+
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[test]
 fn when_email_is_wrong_then_login_failed() {
-    let username = "test_viewer";
+    let username = format!("testViewer{}", rand::random::<u32>());
     let email = format!("{}@gmail.com", username);
     let password = "1234";
     let output = create_test_user(&username, &email, password, "viewer");
 
-    println!("{:?}", output);
+    println!("4{:?}", output);
 
     let client = Client::new();
 
@@ -170,6 +109,9 @@ fn when_email_is_wrong_then_login_failed() {
         }))
         .send()
         .unwrap();
+
+    // Cleanup
+    delete_test_user(output);
 
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
@@ -226,7 +168,7 @@ fn when_user_exist_then_signup_failed() {
     let password = "123456aA";
     let output = create_test_user(&username, &email, password, "viewer");
 
-    println!("{:?}", output);
+    println!("5{:?}", output);
 
     let client = Client::new();
 
@@ -253,7 +195,7 @@ fn when_username_exist_then_signup_returns_username_unavailable_error() {
     let password = "123456aA";
     let output = create_test_user(&username, &email, password, "viewer");
 
-    println!("{:?}", output);
+    println!("6{:?}", output);
 
     let client = Client::new();
 
@@ -331,7 +273,7 @@ fn when_email_exist_then_signup_returns_email_in_use_error() {
     let password = "123456aA";
     let output = create_test_user(&username, &email, password, "viewer");
 
-    println!("{:?}", output);
+    println!("7{:?}", output);
 
     let client = Client::new();
 
@@ -457,7 +399,7 @@ fn when_email_correct_and_exists_password_reset_success() {
     let password = "123456aA";
     let output = create_test_user(&username, &email, password, "viewer");
 
-    println!("{:?}", output);
+    println!("8{:?}", output);
 
     let client = Client::new();
 
@@ -510,4 +452,114 @@ fn when_email_is_not_present_then_password_reset_returns_email_not_exist_error()
     let error: ApiError = from_value(json).unwrap();
 
     assert_eq!(error, AuthError::EmailNotExist.value());
+}
+
+#[test]
+fn when_password_wrong_then_password_failed() {
+    let client = Client::new();
+    let token = generate_test_token(SESSION_ID_LENGTH);
+
+    let response = client
+        .put(format!("{}/password/{token}", common::APP_HOST))
+        .json(&json!({
+            "password":"1234",
+            "confirmation":"1234"
+        }))
+        .send()
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn when_password_wrong_then_password_returns_invalid_password_error() {
+    let client = Client::new();
+    let token = generate_test_token(SESSION_ID_LENGTH);
+
+    let response = client
+        .put(format!("{}/password/{token}", common::APP_HOST))
+        .json(&json!({
+            "password":"1234",
+            "confirmation":"1234"
+        }))
+        .send()
+        .unwrap();
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, AuthError::InvalidPassword.value())
+}
+
+#[test]
+fn when_confirmation_is_not_match_then_password_returns_invalid_password_error() {
+    let client = Client::new();
+    let token = generate_test_token(SESSION_ID_LENGTH);
+
+    let response = client
+        .put(format!("{}/password/{token}", common::APP_HOST))
+        .json(&json!({
+            "password":"123456aA",
+            "confirmation":"123456aB"
+        }))
+        .send()
+        .unwrap();
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, AuthError::InvalidPassword.value())
+}
+
+#[test]
+fn when_token_length_is_incorrect_then_password_returns_invalid_token_error() {
+    let client = Client::new();
+    let token = generate_test_token(64);
+
+    let response = client
+        .put(format!("{}/password/{token}", common::APP_HOST))
+        .json(&json!({
+            "password":"123456aA",
+            "confirmation":"123456aA"
+        }))
+        .send()
+        .unwrap();
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, AuthError::InvalidToken.value())
+}
+
+#[test]
+fn when_token_wrong_or_expired_then_password_returns_unauthorized_status() {
+    let client = Client::new();
+    let token = generate_test_token(SESSION_ID_LENGTH);
+
+    let response = client
+        .put(format!("{}/password/{token}", common::APP_HOST))
+        .json(&json!({
+            "password":"123456aA",
+            "confirmation":"123456aA"
+        }))
+        .send()
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED)
+}
+
+#[test]
+fn when_token_missed_then_password_returns_not_found_status() {
+    let client = Client::new();
+
+    let response = client
+        .put(format!("{}/password/", common::APP_HOST))
+        .json(&json!({
+            "password":"123456aA",
+            "confirmation":"123456aA"
+        }))
+        .send()
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,5 @@
+use rand::distributions::Alphanumeric;
+use rand::Rng;
 use reqwest::blocking::{Client, ClientBuilder};
 use reqwest::header::{self, HeaderMap, HeaderValue};
 use reqwest::StatusCode;
@@ -42,8 +44,8 @@ pub fn delete_test_user(create_output: Output) {
         .status();
 }
 
-pub fn get_logged_in_client(username: &str, email: &str, role: &str) -> Client {
-    let password = "1234";
+pub fn get_logged_in_client(username: &str, email: &str, role: &str) -> (Client, Output) {
+    let password = "123456aA";
     let output = create_test_user(username, email, password, role);
 
     println!("{:?}", output);
@@ -69,16 +71,30 @@ pub fn get_logged_in_client(username: &str, email: &str, role: &str) -> Client {
         HeaderValue::from_str(&auth_header).unwrap(),
     );
 
-    ClientBuilder::new()
+    let client = ClientBuilder::new()
         .default_headers(headers)
         .build()
-        .unwrap()
+        .unwrap();
+
+    return (client, output);
 }
 
-pub fn get_client_with_logged_in_viewer() -> Client {
-    get_logged_in_client("test_viewer", "test_viewer@gmail.com", "viewer")
+pub fn get_client_with_logged_in_viewer() -> (Client, Output) {
+    let username = format!("testViewer{}", rand::random::<u32>());
+    let email = format!("{}@gmail.com", username);
+    get_logged_in_client(username.as_str(), email.as_str(), "viewer")
 }
 
-pub fn get_client_with_logged_in_editor() -> Client {
-    get_logged_in_client("test_editor", "test_editor@gmail.com", "editor")
+pub fn get_client_with_logged_in_editor() -> (Client, Output) {
+    let username = format!("testEditor{}", rand::random::<u32>());
+    let email = format!("{}@gmail.com", username);
+    get_logged_in_client(username.as_str(), email.as_str(), "editor")
+}
+
+pub fn generate_test_token(length: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(length)
+        .map(char::from)
+        .collect()
 }

--- a/tests/profile.rs
+++ b/tests/profile.rs
@@ -1,0 +1,191 @@
+use reqwest::{blocking::Client, StatusCode};
+use rocket::serde::json::json;
+use rust_template::errors::{ApiError, AuthError};
+use serde_json::{from_value, Value};
+
+use crate::common::{
+    delete_test_user, get_client_with_logged_in_editor, get_client_with_logged_in_viewer,
+};
+
+pub mod common;
+
+#[test]
+fn when_session_is_active_and_role_viewer_then_me_success() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .get(format!("{}/profile/me", common::APP_HOST))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test]
+fn when_session_is_active_and_role_editor_then_me_success() {
+    let (client, create_user_output) = get_client_with_logged_in_editor();
+
+    let response = client
+        .get(format!("{}/profile/me", common::APP_HOST))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test]
+fn when_session_is_active_and_role_viewer_then_me_returns_username_and_email() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .get(format!("{}/profile/me", common::APP_HOST))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+    assert_eq!(
+        {
+            json.get("username").unwrap();
+            json.get("email").unwrap();
+        },
+        {
+            "test_viewer";
+            "test_viewer@gmail.com";
+        },
+    );
+}
+
+#[test]
+fn when_session_is_active_and_me_success_then_password_is_none() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .get(format!("{}/profile/me", common::APP_HOST))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+    assert!(json.get("password").is_none());
+}
+
+#[test]
+fn when_session_is_not_active_me_failed() {
+    let client = Client::new();
+
+    let response = client
+        .get(format!("{}/profile/me", common::APP_HOST))
+        .send()
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn when_session_is_active_and_payload_is_correct_then_password_success() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .put(format!("{}/profile/password", common::APP_HOST))
+        .json(&json!({
+            "password": "123456aA",
+            "confirmation": "123456aA"
+        }))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test]
+fn when_session_is_not_active_then_password_returns_unauthorized_status() {
+    let client = Client::new();
+
+    let response = client
+        .put(format!("{}/profile/password", common::APP_HOST))
+        .json(&json!({
+            "password": "123456aA",
+            "confirmation": "123456aA"
+        }))
+        .send()
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn when_session_is_active_and_password_is_wrong_then_password_failed() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .put(format!("{}/profile/password", common::APP_HOST))
+        .json(&json!({
+            "password": "1234",
+            "confirmation": "123456aA"
+        }))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn when_session_is_active_and_password_is_wrong_then_password_returns_invalid_password_error() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .put(format!("{}/profile/password", common::APP_HOST))
+        .json(&json!({
+            "password": "1234",
+            "confirmation": "123456aA"
+        }))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, AuthError::InvalidPassword.value());
+}
+
+#[test]
+fn when_session_is_active_and_confirmation_not_match_then_password_returns_invalid_password_err() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .put(format!("{}/profile/password", common::APP_HOST))
+        .json(&json!({
+            "password": "123456aA",
+            "confirmation": "123456aB"
+        }))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, AuthError::InvalidPassword.value());
+}


### PR DESCRIPTION
Implemented `PUT /password/<token>` endpoint to change password via password reset flow (#25);
Implemented `PUT /profile/password` endpoint to change password from profile settings (#28)