### PR TITLE
Add a custom scheme for deep links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,14 @@ on:
   push:
     branches:
       - "main"
+  workflow_run:
+    workflows: ["tests"]
+    types:
+      - completed
 
 jobs:
   build_and_deploy:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     environment: DEV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,14 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_run:
+    workflows: ["lint"]
+    types:
+      - completed
 
 jobs:
   build_and_test:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/src/rocket_routes/authorization.rs
+++ b/src/rocket_routes/authorization.rs
@@ -1,4 +1,7 @@
-use super::{server_error, ClientAddr, DbConnection, DEEP_LINK_HOST, DEEP_LINK_SCHEME};
+use super::{
+    server_error, ClientAddr, DbConnection, DEEP_LINK_APP_SCHEME, DEEP_LINK_HOST,
+    DEEP_LINK_SCHEME,
+};
 use crate::{
     auth::{
         self, generate_token, is_email_valid, is_password_valid, validate_signup_credentials,
@@ -408,7 +411,7 @@ pub async fn confirm_signup(
             .await;
     }
 
-    let deep_link = format!("{DEEP_LINK_SCHEME}://{DEEP_LINK_HOST}");
+    let deep_link = format!("{DEEP_LINK_APP_SCHEME}://{DEEP_LINK_HOST}");
     let base_url = std::env::var("BASE_URL").expect("Unable to read base URL from env");
     let link = format!("{base_url}/{CONFIRM_EMAIL_PATH}");
     let context = context! {

--- a/src/rocket_routes/mod.rs
+++ b/src/rocket_routes/mod.rs
@@ -25,6 +25,7 @@ use crate::repositories::UserRepository;
 
 pub const DEEP_LINK_HOST: &str = "template.softteco.com.deep_link";
 pub const DEEP_LINK_SCHEME: &str = "https";
+pub const DEEP_LINK_APP_SCHEME: &str = "tmplt";
 const AUTH_TYPE: &str = "Bearer";
 const IP_GEOLOCATION_API_URI: &str = "https://freeipapi.com/api/json";
 const IP_GEOLOCATION_DURATION: u64 = 5;


### PR DESCRIPTION
## Summary

- The custom schema (`tmpl`) was used for the deep link on the signup confirmation page;
- Configured a dependency chain for GitHub Actions workflows

## Reasons

- The signup confirmation page opens through the WebView of the email client. The mobile version of the confirmation page contains a deep link to the application. But currently we only use `http` and `https` deep link schemes. Because of this, WebView opens the link as a normal link rather than handling it as a deep link.
- The GitHub Actions workflows started at the same time. Because of this, the `deploy` workflow may have finished before `test` and not depend on its result.

## References

- closes #54

