### PR TITLE
Implement a user update endpoint

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -29,6 +29,7 @@ async fn main() {
             authorization::confirm_signup,
             profile::me,
             profile::update_password,
+            profile::update_user,
         ),
         components(schemas(
             dto::UserProfileDto,
@@ -38,7 +39,9 @@ async fn main() {
             dto::NewUserDto,
             dto::NewUserResponseDto,
             dto::ResetPasswordEmailDto,
+            dto::UpdateUserDto,
             errors::AuthError,
+            errors::ProfileError,
         )),
         modifiers(&SecurityAddon),
     )]
@@ -70,6 +73,7 @@ async fn main() {
                 authorization::confirm_signup,
                 profile::me,
                 profile::update_password,
+                profile::update_user,
             ],
         )
         .mount(

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -82,3 +82,16 @@ pub struct UserProfileDto {
     #[schema(value_type=Vec<String>,example="2023-10-12T10:00:14.930859")]
     pub created_at: NaiveDateTime,
 }
+
+/// User profile update body
+#[derive(serde::Deserialize, ToSchema)]
+pub struct UpdateUserDto {
+    #[schema(example = "Edward")]
+    pub first_name: Option<String>,
+    #[schema(example = "Falcon")]
+    pub last_name: Option<String>,
+    #[schema(example = "Great Britain")]
+    pub country: Option<String>,
+    #[schema(value_type=Option<Vec<String>>,example="1970-01-01")]
+    pub birth_date: Option<NaiveDate>,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -72,3 +72,39 @@ impl AuthError {
         }
     }
 }
+
+#[derive(Debug, serde::Deserialize, PartialEq, ToSchema)]
+pub enum ProfileError {
+    InvalidFirstName,
+    InvalidLastName,
+    InvalidCountry,
+    InvalidBirthDate,
+}
+
+impl ProfileError {
+    pub fn value(&self) -> ApiError {
+        const ERROR_TYPE: &str = "profile_error";
+        match self {
+            ProfileError::InvalidFirstName => ApiError {
+                error_type: ERROR_TYPE.to_string(),
+                code: "invalid_first_name".to_string(),
+                message: "Invalid first name".to_string(),
+            },
+            ProfileError::InvalidLastName => ApiError {
+                error_type: ERROR_TYPE.to_string(),
+                code: "invalid_last_name".to_string(),
+                message: "Invalid last name".to_string(),
+            },
+            ProfileError::InvalidCountry => ApiError {
+                error_type: ERROR_TYPE.to_string(),
+                code: "invalid_country".to_string(),
+                message: "Invalid country".to_string(),
+            },
+            ProfileError::InvalidBirthDate => ApiError {
+                error_type: ERROR_TYPE.to_string(),
+                code: "invalid_birth_date".to_string(),
+                message: "Birth date must be in YYYY-MM-DD format".to_string(),
+            },
+        }
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,7 +6,7 @@ use diesel::{
     deserialize::{FromSql, FromSqlRow},
     expression::AsExpression,
     pg::{Pg, PgValue},
-    prelude::{Associations, Identifiable},
+    prelude::{AsChangeset, Associations, Identifiable},
     serialize::{IsNull, Output, ToSql},
     sql_types::Text,
     Insertable, Queryable,
@@ -25,6 +25,7 @@ pub struct User {
     pub country: Option<String>,
     pub birth_date: Option<NaiveDate>,
     pub created_at: NaiveDateTime,
+    #[serde(skip_serializing)]
     pub confirmed: bool,
 }
 
@@ -65,6 +66,15 @@ pub struct UserRole {
 pub struct NewUserRole {
     pub user_id: i32,
     pub role_id: i32,
+}
+
+#[derive(AsChangeset)]
+#[diesel(table_name=users)]
+pub struct UpdatedUserInfo {
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub country: Option<String>,
+    pub birth_date: Option<NaiveDate>,
 }
 
 #[derive(AsExpression, FromSqlRow, Debug)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -69,6 +69,7 @@ pub struct NewUserRole {
 }
 
 #[derive(AsChangeset)]
+#[diesel(treat_none_as_null = true)]
 #[diesel(table_name=users)]
 pub struct UpdatedUserInfo {
     pub first_name: Option<String>,

--- a/src/repositories.rs
+++ b/src/repositories.rs
@@ -1,5 +1,7 @@
 use crate::auth::{SESSIONS_KEY_PREFIX, SESSION_LIFE_TIME};
-use crate::models::{NewRole, NewUser, NewUserRole, Role, RoleCode, User, UserRole};
+use crate::models::{
+    NewRole, NewUser, NewUserRole, Role, RoleCode, UpdatedUserInfo, User, UserRole,
+};
 use crate::rocket_routes::CacheConnection;
 use crate::schema::{roles, user_roles, users};
 use diesel::{prelude::*, RunQueryDsl};
@@ -103,6 +105,16 @@ impl UserRepository {
     pub fn confirm_signup(connection: &mut PgConnection, id: i32) -> QueryResult<User> {
         diesel::update(users::table.find(id))
             .set(users::confirmed.eq(true))
+            .get_result(connection)
+    }
+
+    pub fn update_user(
+        connection: &mut PgConnection,
+        id: i32,
+        user_info: UpdatedUserInfo,
+    ) -> QueryResult<User> {
+        diesel::update(users::table.find(id))
+            .set(user_info)
             .get_result(connection)
     }
 }

--- a/src/rocket_routes/mod.rs
+++ b/src/rocket_routes/mod.rs
@@ -119,6 +119,30 @@ impl<'r> FromRequest<'r> for User {
     }
 }
 
+// #[rocket::async_trait]
+// impl<'r> FromData<'r> for UpdateUserDto {
+//     type Error = Value;
+
+//     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
+//         let string = match data
+//             .open(req.limits().get("birth_date").unwrap_or(256.bytes()))
+//             .into_string()
+//             .await
+//         {
+//             Ok(string) if string.is_complete() => string.into_inner(),
+//             _ => return Outcome::Error((Status::PayloadTooLarge, "Date too large")),
+//         };
+
+//         match NaiveDate::parse_from_str(&string, "%Y-%m-%d") {
+//             Ok(date) => Outcome::Success(date),
+//             Err(_) => Outcome::Error((
+//                 Status::UnprocessableEntity,
+//                 ProfileError::InvalidBirthDate.value(),
+//             )),
+//         }
+//     }
+// }
+
 pub async fn get_client_info(client_addr: IpAddr) -> Result<String, Box<dyn std::error::Error>> {
     let date_time = Utc::now().format("%d %B %Y, %H:%M UTC").to_string();
 
@@ -163,7 +187,10 @@ impl Fairing for Cors {
 
     async fn on_response<'r>(&self, _req: &'r Request<'_>, res: &mut rocket::Response<'r>) {
         res.set_raw_header("Access-Control-Allow-Origin", "*");
-        res.set_raw_header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+        res.set_raw_header(
+            "Access-Control-Allow-Methods",
+            "GET, POST, PUT, DELETE, PATCH",
+        );
         res.set_raw_header("Access-Control-Allow-Headers", "*");
         res.set_raw_header("Access-Control-Allow-Credentials", "true");
     }

--- a/tests/authorization.rs
+++ b/tests/authorization.rs
@@ -622,7 +622,7 @@ fn when_any_request_is_received_then_response_contains_cors_headers() {
     assert_eq!(headers.get(ACCESS_CONTROL_ALLOW_HEADERS).unwrap(), "*");
     assert_eq!(
         headers.get(ACCESS_CONTROL_ALLOW_METHODS).unwrap(),
-        "GET, POST, PUT, DELETE"
+        "GET, POST, PUT, DELETE, PATCH"
     );
     assert_eq!(
         headers.get(ACCESS_CONTROL_ALLOW_CREDENTIALS).unwrap(),

--- a/tests/profile.rs
+++ b/tests/profile.rs
@@ -1,6 +1,7 @@
+use common::get_logged_in_client;
 use reqwest::{blocking::Client, StatusCode};
 use rocket::serde::json::json;
-use rust_template::errors::{ApiError, AuthError};
+use rust_template::errors::{ApiError, AuthError, ProfileError};
 use serde_json::{from_value, Value};
 
 use crate::common::{
@@ -41,7 +42,10 @@ fn when_session_is_active_and_role_editor_then_me_success() {
 
 #[test]
 fn when_session_is_active_and_role_viewer_then_me_returns_username_and_email() {
-    let (client, create_user_output) = get_client_with_logged_in_viewer();
+    let username = format!("testViewer{}", rand::random::<u32>());
+    let email = format!("{}@gmail.com", username);
+    let (client, create_user_output) =
+        get_logged_in_client(username.as_str(), email.as_str(), "viewer");
 
     let response = client
         .get(format!("{}/profile/me", common::APP_HOST))
@@ -53,14 +57,8 @@ fn when_session_is_active_and_role_viewer_then_me_returns_username_and_email() {
 
     let json: Value = response.json().unwrap();
     assert_eq!(
-        {
-            json.get("username").unwrap();
-            json.get("email").unwrap();
-        },
-        {
-            "test_viewer";
-            "test_viewer@gmail.com";
-        },
+        (json.get("username").unwrap(), json.get("email").unwrap()),
+        (&json!(username), &json!(email)),
     );
 }
 
@@ -191,4 +189,270 @@ fn when_session_is_active_and_confirmation_not_match_then_password_returns_inval
     let error: ApiError = from_value(json).unwrap();
 
     assert_eq!(error, AuthError::InvalidPassword.value());
+}
+
+#[test]
+fn when_new_data_is_valid_then_update_user_returns_updated_user() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({
+                "first_name": "Edward",
+                "last_name": "Falcon",
+                "country": "Great Britain",
+                "birth_date": "1970-01-01"
+        }))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+
+    assert_eq!(
+        (
+            json.get("first_name").unwrap(),
+            json.get("last_name").unwrap(),
+            json.get("country").unwrap(),
+            json.get("birth_date").unwrap(),
+        ),
+        (
+            &json!("Edward"),
+            &json!("Falcon"),
+            &json!("Great Britain"),
+            &json!("1970-01-01"),
+        ),
+    );
+}
+
+#[test]
+fn when_first_name_is_valid_then_update_user_returns_updated_user() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"first_name": "Edward"}))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+
+    assert_eq!(json.get("first_name").unwrap(), &json!("Edward"));
+}
+
+#[test]
+fn when_last_name_is_valid_then_update_user_returns_updated_user() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"last_name": "Falcon"}))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+
+    assert_eq!(json.get("last_name").unwrap(), &json!("Falcon"));
+}
+
+#[test]
+fn when_country_is_valid_then_update_user_returns_updated_user() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"country": "Great Britain"}))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+
+    assert_eq!(json.get("country").unwrap(), &json!("Great Britain"));
+}
+
+#[test]
+fn when_birth_date_is_valid_then_update_user_returns_updated_user() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"birth_date": "1970-01-01"}))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+
+    assert_eq!(json.get("birth_date").unwrap(), &json!("1970-01-01"));
+}
+
+#[test]
+fn when_name_is_invalid_or_empty_then_update_user_returns_invalid_first_name_error() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let _response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"first_name": "Edward"}))
+        .send()
+        .unwrap();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"first_name": ""}))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, ProfileError::InvalidFirstName.value());
+}
+
+#[test]
+fn when_last_name_is_invalid_or_empty_then_update_user_returns_invalid_last_name_error() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let _response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"last_name": "Falcon 9"}))
+        .send()
+        .unwrap();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"last_name": ""}))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, ProfileError::InvalidLastName.value());
+}
+
+#[test]
+fn when_country_is_invalid_or_empty_then_update_user_returns_invalid_country_error() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let _response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"country": "(qGreat Britain)"}))
+        .send()
+        .unwrap();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"country": ""}))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, ProfileError::InvalidCountry.value());
+}
+
+#[test]
+fn when_birth_data_is_invalid_or_empty_then_update_user_returns_invalid_country_error() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let _response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"birth_date": "01-01-1970"}))
+        .send()
+        .unwrap();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"birth_date": ""}))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, ProfileError::InvalidBirthDate.value());
+}
+
+#[test]
+fn if_values_are_null_patch_user_returns_user_with_null_values() {
+    let (client, create_user_output) = get_client_with_logged_in_viewer();
+
+    let _response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({
+                "first_name": "Edward",
+                "last_name": "Falcon",
+                "country": "Great Britain",
+                "birth_date": "1970-01-01",
+        }))
+        .send()
+        .unwrap();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({
+                "first_name": null,
+                "last_name": null,
+                "country": null,
+                "birth_date":null,
+        }))
+        .send()
+        .unwrap();
+
+    // Cleanup
+    delete_test_user(create_user_output);
+
+    let json: Value = response.json().unwrap();
+
+    assert_eq!(
+        (
+            json.get("first_name").unwrap(),
+            json.get("last_name").unwrap(),
+            json.get("country").unwrap(),
+            json.get("birth_date").unwrap(),
+        ),
+        (&json!(null), &json!(null), &json!(null), &json!(null),),
+    );
+}
+
+#[test]
+fn when_session_is_not_active_then_update_user_returns_unauthorized_status() {
+    let client = Client::new();
+
+    let response = client
+        .patch(format!("{}/profile/user", common::APP_HOST))
+        .json(&json!({"first_name": "Edward"}))
+        .send()
+        .unwrap();
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, AuthError::InvalidToken.value());
 }


### PR DESCRIPTION
## Summary

Implemented `PATCH` API endpoint to update user's personal information

## Reasons.

To improve user experience and provide seamless profile management through the mobile app, we need to develop a `PATCH` API endpoint that allows users to update their personal information including first name, last name, country and date of birth.

## References

- closes #34 