### PR TITLE
Implement an endpoint for deleting a user

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -30,6 +30,7 @@ async fn main() {
             profile::me,
             profile::update_password,
             profile::update_user,
+            profile::delete_user,
         ),
         components(schemas(
             dto::UserProfileDto,
@@ -74,6 +75,7 @@ async fn main() {
                 profile::me,
                 profile::update_password,
                 profile::update_user,
+                profile::delete_user,
             ],
         )
         .mount(

--- a/src/rocket_routes/mod.rs
+++ b/src/rocket_routes/mod.rs
@@ -119,30 +119,6 @@ impl<'r> FromRequest<'r> for User {
     }
 }
 
-// #[rocket::async_trait]
-// impl<'r> FromData<'r> for UpdateUserDto {
-//     type Error = Value;
-
-//     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
-//         let string = match data
-//             .open(req.limits().get("birth_date").unwrap_or(256.bytes()))
-//             .into_string()
-//             .await
-//         {
-//             Ok(string) if string.is_complete() => string.into_inner(),
-//             _ => return Outcome::Error((Status::PayloadTooLarge, "Date too large")),
-//         };
-
-//         match NaiveDate::parse_from_str(&string, "%Y-%m-%d") {
-//             Ok(date) => Outcome::Success(date),
-//             Err(_) => Outcome::Error((
-//                 Status::UnprocessableEntity,
-//                 ProfileError::InvalidBirthDate.value(),
-//             )),
-//         }
-//     }
-// }
-
 pub async fn get_client_info(client_addr: IpAddr) -> Result<String, Box<dyn std::error::Error>> {
     let date_time = Utc::now().format("%d %B %Y, %H:%M UTC").to_string();
 

--- a/tests/authorization.rs
+++ b/tests/authorization.rs
@@ -1,3 +1,4 @@
+use common::SESSION_ID_LENGTH;
 use reqwest::{
     blocking::Client,
     header::{
@@ -16,8 +17,6 @@ use serde_json::{from_value, json, Value};
 use crate::common::{create_test_user, delete_test_user, generate_test_token};
 
 pub mod common;
-
-const SESSION_ID_LENGTH: usize = 128;
 
 #[test]
 fn when_credentials_correct_then_login_success() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value};
 use std::process::{Command, Output};
 
 pub const APP_HOST: &'static str = "http://127.0.0.1:8000";
+pub const SESSION_ID_LENGTH: usize = 128;
 
 pub fn create_test_user(
     username: &str,

--- a/tests/profile.rs
+++ b/tests/profile.rs
@@ -456,3 +456,30 @@ fn when_session_is_not_active_then_update_user_returns_unauthorized_status() {
 
     assert_eq!(error, AuthError::InvalidToken.value());
 }
+
+#[test]
+fn when_session_is_active_then_delete_user_returns_no_content_status() {
+    let (client, _) = get_client_with_logged_in_editor();
+
+    let response = client
+        .delete(format!("{}/profile/user", common::APP_HOST))
+        .send()
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[test]
+fn when_token_wrong_or_expired_then_delete_user_returns_invalid_token_error() {
+    let client = Client::new();
+
+    let response = client
+        .delete(format!("{}/profile/user", common::APP_HOST))
+        .send()
+        .unwrap();
+
+    let json: Value = response.json().unwrap();
+    let error: ApiError = from_value(json).unwrap();
+
+    assert_eq!(error, AuthError::InvalidToken.value());
+}


### PR DESCRIPTION
## Summary

Implemented **DELETE** `/profile/user`API endpoint for deleting a user profile.

## Reasons.

The **DELETE** `/profile/user` API endpoint allows users to delete their accounts. This feature is necessary to provide user autonomy and data privacy, ensuring that users can effectively manage their presence in the system.

## References

- closes #56